### PR TITLE
add follow stubbing to ng-hal-mocks

### DIFF
--- a/karma/karma-unit.js
+++ b/karma/karma-unit.js
@@ -9,7 +9,8 @@ module.exports = function ( config ) {
      * This is the list of file patterns to load into the browser during testing.
      */
     files: [
-      'public/**/*.js'
+      'public/**/*.js',
+      'src/common/angular-hal-mock.js'
     ],
     exclude: [
       'public/assets/**/*.js'
@@ -18,7 +19,7 @@ module.exports = function ( config ) {
     frameworks: [ 'jasmine' ],
     plugins: [ 'karma-jasmine', 'karma-firefox-launcher', 'karma-chrome-launcher', 'karma-safari-launcher', 'karma-phantomjs-launcher', 'karma-coffee-preprocessor', 'karma-coverage' ],
     preprocessors: {
-       'public/{app,common}/**/*.js': ['coverage']
+       '*/{app,common}/**/!(*.spec).js': ['coverage']
     },
 
     /**

--- a/src/common/angular-hal-mock.js
+++ b/src/common/angular-hal-mock.js
@@ -1,105 +1,75 @@
-angular.module('angular-hal-mock', ['angular-hal', 'ngMock', 'ng'])
-.config(function ($provide, ngHalProvider) {
-  ngHalProvider.setRootUrl('/');
+(function () {
+  var $q;
+  angular.module('angular-hal-mock', ['angular-hal', 'ngMock', 'ng'])
+  .config(function ($provide, ngHalProvider) {
 
-  if (typeof window.jasmine !== 'undefined') {
-    beforeEach(function () {
-      window.resolutionOf = function (stateName, name, params) {
-        var result = {_isResolution : true};
-        result.toString = function () {
-          return "the resolution '" + this.name + "' of the state '" +stateName+ "'";
+    function unfolded(doc) {
+      if (angular.isFunction(doc.links)) {
+        doc._links = doc.links.dump();
+      }
+      return doc;
+    }
+
+    function promised(obj) {
+      obj = $q.when(obj);
+      var then = obj.then;
+      obj.then = function () {
+        return promised(then.apply(obj, [].slice.call(arguments)));
+      };
+      obj.follow = function (rel, params) {
+        return promised(this.then(function (d) {
+          return d.follow(rel, params);
+        }));
+      };
+      obj.get = function (prop) {
+        return promised(this.then(function (d) {
+          return d[prop];
+        }));
+      };
+      obj.call = function (meth) {
+        var args = [].slice.call(arguments, 1);
+        return promised(this.then(function (d) {
+          return d[meth].apply(d, args);
+        }));
+      };
+      return obj;
+    }
+
+    function mocked (doc) {
+      var docStubs = {};
+      doc.stubFollow = function (rel, obj) {
+        docStubs[rel] = promised(obj);
+      };
+      var originalFollow = doc.follow;
+      doc.follow = function (rel, params) {
+        if (typeof docStubs[rel] !== 'undefined') {
+          return docStubs[rel];
+        } else {
+          return originalFollow.call(doc, rel, params);
         }
-        inject(function ($state) {
-          result.state = $state.get(stateName);
-          result.invokable = result.state.resolve[name];
-          result.name = name;
-          result.params = params;
-        });
-        return result;
       };
 
-      function ff (fl) {
-        return "'" + fl[0] + "'" + (fl[1] ? " with params: " + JSON.stringify(fl[1]) : '') + ".";
-      }
+      return doc;
+    }
 
-      function expectedFollow (of, df) {
-        return function () {
-          return "Expected " + this.actual + " to follow " + ff(of) + (df ? "\n\tFollowed " + ff(df) : "");
-        };
-      }
-
-      this.addMatchers({
-        toFollow: function (trail) {
-          if (typeof this.actual !== 'object' || !this.actual._isResolution) {
-            this.message = function () { return "Expected " + this.actual + " to be a state resolution."; }
-            return false;
-          }
-
-          if (!angular.isArray(trail)) {
-            trail = [[trail, arguments[1]]];
-          }
-
-          var resolution = this.actual, halMock = {stack: []}, result;
-          halMock.follow = halMock.followOne = jasmine.createSpy('follow').andCallFake(function (rel, params) {
-            halMock.stack.push([rel, params]);
-            return halMock;
-          });
-
-          inject(function ($injector) {
-            result = $injector.invoke(resolution.invokable,
-              null, {$stateParams: resolution.params, ngHal: halMock});
-          });
-
-          if (result !== halMock) {
-            this.message = function () {
-              return "Expected " + this.actual + " to resolve to an ngHal object.";
-            }
-            return false;
-          }
-
-          var stackCopy = halMock.stack.slice(0), errored, ei;
-
-          angular.forEach(trail, function (step, x) {
-            if (!errored) {
-              var foundAt = -1;
-              angular.forEach(stackCopy, function (aStep, i) {
-                if (foundAt == -1 && angular.equals(aStep, step)) {
-                  foundAt = i;
-                }
-              });
-              if (foundAt != -1) {
-                stackCopy.splice(0, foundAt+1);
-              } else {
-                errored = true;
-                ei = x;
-              }
-            }
-          });
-
-          if (errored) {
-            this.message = expectedFollow(trail[ei], stackCopy[0]);
-            return false;
-          }
-
-          return true;
+    ngHalProvider.setRootUrl('/_ngHal_mock_default');
+    $provide.decorator('ngHal', function ($delegate) {
+      $delegate.mock = function mock (o) {
+        var args = Array.prototype.slice.call(arguments);
+        if (angular.isObject(args[args.length-1])) {
+          o = args.pop();
+        } else {
+          o = {};
         }
-      });
+
+        return mocked(ngHalProvider.generateConstructor(args)(unfolded(o)));
+      };
+
+      return $delegate;
     });
-  }
-
-  $provide.decorator('ngHal', function ($delegate) {
-    $delegate.mock = function mock () {
-      var args   = Array.prototype.slice.call(arguments);
-      var object;
-      if (!angular.isString(args[args.length-1])) {
-        object = args.pop();
-      } else {
-        object = {};
-      }
-
-      return ngHalProvider.generateConstructor(args)(object);
-    };
-
-    return $delegate;
-  });
-});
+  })
+  .run(['$q', '$httpBackend', function (_$q_, $httpBackend) {
+    $httpBackend.when('GET', '/_ngHal_mock_default').respond({});
+    $q = _$q_;
+  }]);
+})();

--- a/src/common/angular-hal-mock.spec.js
+++ b/src/common/angular-hal-mock.spec.js
@@ -17,4 +17,64 @@ describe('angular-hal-mock', function () {
 
     expect(mock.name).toBe('foo');
   }));
+
+  describe ('with real ngHal requests', function () {
+    beforeEach(module(function (ngHalProvider) {
+      ngHalProvider.setRootUrl('/');
+    }));
+
+    it('can wrap real ngHal documents', inject(function (ngHal, $httpBackend) {
+      var ngHalDoc;
+      $httpBackend.when('GET', '/').respond({a:1, _links: {foo: {href: '/'}}});
+      ngHal.then(function (doc) {
+        ngHalDoc = doc;
+      });
+      $httpBackend.flush();
+
+      var mock = ngHal.mock('http://meta.nghal.org/object', ngHalDoc);
+      expect(mock.a).toBe(1);
+      expect(mock.name).toEqual('foo');
+      expect(mock.link('foo').href()).toEqual('/');
+    }));
+  });
+
+  it('can stub followings', inject(function (ngHal, $rootScope) {
+    var doc1 = ngHal.mock('http://meta.nghal.org/object');
+    var doc2 = ngHal.mock('http://meta.nghal.org/object');
+    var doc3 = ngHal.mock({b:{c:function(a) { return a; }}});
+    var rDoc, result;
+
+    doc1.stubFollow('foo', doc2);
+    doc2.stubFollow('bar', doc3);
+
+    doc1.follow('foo').then(function (d) {
+      rDoc = d;
+      return d;
+    }).follow('bar').get('b').call('c', 2).then(function (b) {
+      result = b;
+    });
+
+    $rootScope.$digest();
+
+    expect(result).toBe(2);
+    expect(rDoc).toBe(doc2);
+  }));
+
+  it('does not interfere with regular following', inject(function (ngHal, $httpBackend) {
+    var doc1 = ngHal.mock('http://meta.nghal.org/object', {_links: {asd: {href: '/asd'}}});
+    var doc2 = ngHal.mock({b:2});
+    doc1.stubFollow('fgh', doc2);
+
+    var asd, fgh;
+
+    $httpBackend.whenGET('/asd').respond({c:3});
+
+    doc1.follow('fgh').then(function (d) { fgh = d; });
+    doc1.follow('asd').then(function (d) { asd = d; });
+
+    $httpBackend.flush();
+
+    expect(asd.c).toBe(3);
+    expect(fgh.b).toBe(2);
+  }));
 });

--- a/src/common/angular-hal.js
+++ b/src/common/angular-hal.js
@@ -150,6 +150,10 @@ angular.module('angular-hal', ['ng', 'uri-template'])
       return obj;
     }
 
+    accessor.dump = function () {
+      return angular.copy(rLinks);
+    };
+
     angular.forEach(Link.prototype, function (method, name) {
       accessor[name] = function (rel, params) {
         return method.call(links[rel], params);


### PR DESCRIPTION
you can wrap an existing hal document in the loving embrace of a mock
by calling `ngHal.mock(document);`

you can stub out followings using the `#stubFollow()` method. This
allows you to follow a chain without a whole bunch of $httpBackend
nonsense.

Also, added angular-hal-mock to coverage reporting.
