### PR TITLE
Allow stubbing all the way at the root of ngHal

### DIFF
--- a/src/common/angular-hal-mock.js
+++ b/src/common/angular-hal-mock.js
@@ -1,75 +1,92 @@
-(function () {
-  var $q;
-  angular.module('angular-hal-mock', ['angular-hal', 'ngMock', 'ng'])
-  .config(function ($provide, ngHalProvider) {
+angular.module('angular-hal-mock', ['angular-hal', 'ngMock', 'ng'])
+.config(function ($provide, ngHalProvider) {
+  var $q, FAKE_ROOT = 'http://nghal.org/fake_root';
 
-    function unfolded(doc) {
-      if (angular.isFunction(doc.links)) {
-        doc._links = doc.links.dump();
-      }
-      return doc;
+  function unfolded(doc) {
+    if (angular.isFunction(doc.links)) {
+      doc._links = doc.links.dump();
     }
+    return doc;
+  }
 
-    function promised(obj) {
-      obj = $q.when(obj);
-      var then = obj.then;
-      obj.then = function () {
-        return promised(then.apply(obj, [].slice.call(arguments)));
-      };
-      obj.follow = function (rel, params) {
-        return promised(this.then(function (d) {
-          return d.follow(rel, params);
-        }));
-      };
-      obj.get = function (prop) {
-        return promised(this.then(function (d) {
-          return d[prop];
-        }));
-      };
-      obj.call = function (meth) {
-        var args = [].slice.call(arguments, 1);
-        return promised(this.then(function (d) {
-          return d[meth].apply(d, args);
-        }));
-      };
+  function promised(obj) {
+    var sfs = [];
+    obj = $q.when(obj).then(function (obj) {
+      angular.forEach(sfs, function (sf) {
+        obj.stubFollow.apply(obj, sf);
+      });
       return obj;
-    }
-
-    function mocked (doc) {
-      var docStubs = {};
-      doc.stubFollow = function (rel, obj) {
-        docStubs[rel] = promised(obj);
-      };
-      var originalFollow = doc.follow;
-      doc.follow = function (rel, params) {
-        if (typeof docStubs[rel] !== 'undefined') {
-          return docStubs[rel];
-        } else {
-          return originalFollow.call(doc, rel, params);
-        }
-      };
-
-      return doc;
-    }
-
-    ngHalProvider.setRootUrl('/_ngHal_mock_default');
-    $provide.decorator('ngHal', function ($delegate) {
-      $delegate.mock = function mock (o) {
-        var args = Array.prototype.slice.call(arguments);
-        if (angular.isObject(args[args.length-1])) {
-          o = args.pop();
-        } else {
-          o = {};
-        }
-
-        return mocked(ngHalProvider.generateConstructor(args)(unfolded(o)));
-      };
-
-      return $delegate;
     });
-  })
-  .run(['$q', '$httpBackend', function (_$q_, $httpBackend) {
-    $httpBackend.when('GET', '/_ngHal_mock_default').respond({});
+    var then = obj.then;
+    obj.stubFollow = function () {
+      sfs.push([].slice.call(arguments));
+    };
+    obj.then = function () {
+      return promised(then.apply(obj, [].slice.call(arguments)));
+    };
+    obj.follow = function (rel, params) {
+      return promised(this.then(function (d) {
+        return d.follow(rel, params);
+      }));
+    };
+    obj.get = function (prop) {
+      return promised(this.then(function (d) {
+        return d[prop];
+      }));
+    };
+    obj.call = function (meth) {
+      var args = [].slice.call(arguments, 1);
+      return promised(this.then(function (d) {
+        return d[meth].apply(d, args);
+      }));
+    };
+    return obj;
+  }
+
+  function mocked (doc) {
+    var docStubs = {};
+    doc.stubFollow = function (rel, obj) {
+      docStubs[rel] = promised(obj);
+    };
+    var originalFollow = doc.follow;
+    doc.follow = function (rel, params) {
+      if (typeof docStubs[rel] !== 'undefined') {
+        return docStubs[rel];
+      } else {
+        return originalFollow.call(doc, rel, params);
+      }
+    };
+
+    return doc;
+  }
+
+  ngHalProvider.setRootUrl(FAKE_ROOT);
+  $provide.decorator('ngHal', ['$delegate', '$httpBackend', '$q', function ($delegate, $httpBackend, _$q_) {
     $q = _$q_;
+
+    if (ngHalProvider.ctx.origin == FAKE_ROOT) {
+      $httpBackend.when('GET', FAKE_ROOT).respond({});
+      $httpBackend.flush(1);
+    }
+    var mock = promised($delegate.then(function (d) {
+      return mocked(d);
+    }));
+
+    mock.context = function () {
+      return $delegate.context.apply($delegate, [].slice.call(arguments));
+    };
+
+    mock.mock = function mock (o) {
+      var args = Array.prototype.slice.call(arguments);
+      if (angular.isObject(args[args.length-1])) {
+        o = args.pop();
+      } else {
+        o = {};
+      }
+
+      return mocked(ngHalProvider.generateConstructor(args)(unfolded(o)));
+    };
+
+    return mock;
   }]);
-})();
+});

--- a/src/common/angular-hal-mock.spec.js
+++ b/src/common/angular-hal-mock.spec.js
@@ -77,4 +77,40 @@ describe('angular-hal-mock', function () {
     expect(asd.c).toBe(3);
     expect(fgh.b).toBe(2);
   }));
+
+  it ('can stubFollow on the root node', inject(function (ngHal, $rootScope) {
+    var result;
+    ngHal.then(function (d) {
+      d.stubFollow('foo', {a: 1});
+      return d;
+    }).follow('foo').get('a').then(function(a) {
+      result = a;
+    });
+
+    $rootScope.$digest();
+
+    expect(result).toBe(1);
+  }));
+
+  it ('has a shorthand to stubFollow on stubbed promises', inject(function (ngHal, $rootScope) {
+    var result;
+    ngHal.stubFollow('foo', ngHal.mock('http://meta.nghal.org/object', {id:3}));
+    ngHal.follow('foo').call('getId').then(function (id) { result = id; });
+    $rootScope.$digest();
+    expect(result).toBe(3);
+  }));
+
+  it ('does not interfere with contexts', function () {
+    module(function (ngHalProvider) {
+      ngHalProvider.context('foo').setRootUrl('/asd');
+    });
+
+    inject(function (ngHal, $httpBackend) {
+      var href;
+      $httpBackend.whenGET('/asd').respond({});
+      ngHal.context('foo').url().then(function (url) { href = url; });
+      $httpBackend.flush();
+      expect(href).toBe('/asd');
+    });
+  });
 });


### PR DESCRIPTION
lets you do things like:

``` javascript
ngHal.stubFollow('stories', ngHal.mock('http://meta.prx.org/model/story', {title: 'foo'}));
```

at that point, `ngHal.follow('stories')` (anywhere in the code) will point at your mock object.

This makes testing your `resolve`s much easier.
