### PR TITLE
allow overriding feature flags via env vars

### DIFF
--- a/lib/gulp-featureflags.js
+++ b/lib/gulp-featureflags.js
@@ -49,6 +49,16 @@ module.exports = function () {
       flags = JSON.parse(fs.readFileSync(flagFile));
     }
 
+    Object.keys(flags).forEach(function (key) {
+      if (typeof process.env[key] !== 'undefined') {
+        try {
+          flags[key] = JSON.parse(process.env[key])
+        } catch(e) {
+          flags[key] = process.env[key]
+        }
+      }
+    });
+
     if (file.isStream()) {
       this.emit('error', new gutil.PluginError('gulp-featureflags', 'streams not supported'));
     }


### PR DESCRIPTION
I sometimes need to set the server uri or something to a different value temporarily. It's sort of a pain in the neck to avoid checking a file in (and it's appropriate to have the file checked in because it is sort of an indication of what is ready for release etc) so I added the ability to override those values with ENV vars.
