### PR TITLE
Disable google analytics in development.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -24,7 +24,7 @@
   <a class="full-site" ng-href="{{app.desktopUrl}}">Show Desktop Site</a>
   <prx-global-player></prx-global-player>
 <% if (!compile) { %><script src="http://localhost:35729/livereload.js"></script>
-<% } %><script>
+<% } else { %><script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -32,7 +32,7 @@
   ga('create', 'UA-164824-46', 'prx.org');
   ga('require', 'linkid', 'linkid.js');
   ga('require', 'displayfeatures');
-</script><% scripts.forEach(function(file) { %>
+</script><% } scripts.forEach(function(file) { %>
 <script <%= compile ? 'async ' : ''%>src="<%= file %>"></script><% }); %>
 </body>
 </html>


### PR DESCRIPTION
Has the side effect property of forcing all experiments to happen
under a single global identifier, so experiment data is also impacted
less in development.
