### PR TITLE
set version dimension in google analytics

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -11,7 +11,9 @@ namespace :deploy do
     on roles(:web) do
       within release_path do
         execute :npm, 'install'
-        execute :npm, 'run-script compile'
+        with application_version: fetch(:current_revision) do
+          execute :npm, 'run-script compile'
+        end
       end
     end
   end

--- a/config/flags.dev.json
+++ b/config/flags.dev.json
@@ -4,5 +4,6 @@
   "lovesharebuy": false,
   "COUNT_HOST": "http://localhost",
   "LISTEN_LATER": true,
-  "HOME_PAGE": false
+  "HOME_PAGE": false,
+  "APPLICATION_VERSION": "development"
 }

--- a/config/flags.release.json
+++ b/config/flags.release.json
@@ -4,5 +4,6 @@
   "lovesharebuy": false,
   "COUNT_HOST": "https://count.prx.org",
   "LISTEN_LATER": false,
-  "HOME_PAGE": false
+  "HOME_PAGE": false,
+  "APPLICATION_VERSION": "integration"
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -244,6 +244,7 @@ gulp.task('distHtml', function () {
   };
   return gulp.src(c.app.html)
     .pipe(templt(ctx))
+    .pipe(feats(featDist, {strict: true, default: false}))
     .pipe(gulp.dest(complDir));
 });
 

--- a/src/index.html
+++ b/src/index.html
@@ -30,7 +30,7 @@
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
   ga('create', 'UA-164824-46', 'prx.org');
-  ga('require', 'linkid', 'linkid.js');
+  ga('set', 'dimension1', FEAT.APPLICATION_VERSION);
   ga('require', 'displayfeatures');
 </script><% } scripts.forEach(function(file) { %>
 <script <%= compile ? 'async ' : ''%>src="<%= file %>"></script><% }); %>


### PR DESCRIPTION
sets the application version in the compiled html to be the deployed git sha sum. This will let us:
- filter out traffic that is being triggered for the purposes of integration testing against a compiled version
- limit queries in google analytics to specific deployed versions.

I've also removed linkid.js until I can figure out how to reverse engineer google's API and send the data ourselves, since they seem not to support dynamic pages like this one. It's currently doubling the amount of time required to load google analytics.
