### PR TITLE
Do not pollute A/B testing data with dev/integration behavior

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -34,7 +34,7 @@ angular.module('prx', ['ngAnimate',
     } else {
       return 'tests';
     }
-  }]);
+  }]).enabled(FEAT.APPLICATION_VERSION != 'development' && FEAT.APPLICATION_VERSION != 'integration');
   ngFlagProvider.flags(FEAT.JSON);
 }).run(function ($rootScope, $location, $analytics, $timeout) {
   $rootScope.$on('$stateChangeSuccess', function () {

--- a/src/common/angular-hal-mock.js
+++ b/src/common/angular-hal-mock.js
@@ -1,52 +1,7 @@
 angular.module('angular-hal-mock', ['angular-hal', 'ngMock', 'ng'])
 .config(function ($provide, ngHalProvider) {
   var $q, $rootScope, FAKE_ROOT = 'http://nghal.org/fake_root';
-
-  beforeEach(function () {
-    jasmine.addMatchers({
-      toResolveTo: function (util, customEquality) {
-        return {
-          compare: function (actual, expected) {
-            var complete = false;
-            inject(function ($q, $rootScope) {
-              $rootScope.$apply(function () {
-                $q.when(actual).then(function (result) {
-                  complete = true;
-                  actual = result;
-                });
-              });
-            });
-            if (!complete) {
-              return { pass: false, message: "Expected promise to resolve."};
-            }
-            var result = {pass: util.equals(actual, expected, customEquality)};
-            if (result.pass) {
-              result.message = "Expected promise not to resolve to " + actual;
-            } else {
-              result.message = "Expected promised " + actual + " to resolve to " + expected;
-            }
-            return result;
-          }
-        };
-      },
-      toResolve: function () {
-        return {
-          compare: function (actual) {
-            var result = {pass: false};
-            inject(function ($q, $rootScope) {
-              $rootScope.$apply(function () {
-                $q.when(actual).then(function () {
-                  result.pass = true;
-                });
-              });
-            });            
-            return result;
-          }
-        };
-      }
-    });
-  });
-
+  
   function unfolded(doc) {
     if (angular.isFunction(doc.links)) {
       doc._links = doc.links.dump();
@@ -95,7 +50,7 @@ angular.module('angular-hal-mock', ['angular-hal', 'ngMock', 'ng'])
         });
       }
       var p = promised(stubbed.then.apply(stubbed, [].slice.call(arguments)));
-      if (!$rootScope.$$phase) { $rootScope.$digest(); } 
+      if (!$rootScope.$$phase) { $rootScope.$digest(); }
       return p;
     };
     obj.follow = function (rel, params) {

--- a/src/common/prx-experiments.spec.js
+++ b/src/common/prx-experiments.spec.js
@@ -4,20 +4,16 @@ describe('prxp', function () {
   function parseKeyValue(keyValue) {
     var obj = {}, key_value, key;
     angular.forEach(keyValue.split('&'), function(keyValue){
-      // if ( keyValue ) {
-        key_value = keyValue.split('=');
-        key = tryDecodeURIComponent(key_value[0]);
-        // if ( angular.isDefined(key) ) {
-          var val = tryDecodeURIComponent(key_value[1]);
-          if (!obj[key]) {
-            obj[key] = val;
-          } else if(angular.isArray(obj[key])) {
-            obj[key].push(val);
-          } else {
-            obj[key] = [obj[key],val];
-          }
-        // }
-      // }
+      key_value = keyValue.split('=');
+      key = tryDecodeURIComponent(key_value[0]);
+      var val = tryDecodeURIComponent(key_value[1]);
+      if (!obj[key]) {
+        obj[key] = val;
+      } else if(angular.isArray(obj[key])) {
+        obj[key].push(val);
+      } else {
+        obj[key] = [obj[key],val];
+      }
     });
     return obj;
   }
@@ -67,94 +63,190 @@ describe('prxp', function () {
   }
 
 
-  beforeEach(module('prx.experiments', function (prxperimentProvider) {
-    prxperimentProvider.clientId('fooBar').base('');
-  }));
+  describe ('configuration', function () {
+    it ('can accept an injectable function for the clientId', function () {
+      module('prx.experiments', function (prxperimentProvider, $provide) {
+        $provide.constant('myClientId', 'testing');
+        prxperimentProvider.clientId(function (myClientId) {
+          return myClientId;
+        });
+      });
 
-  var prxperiment;
-
-  beforeEach(inject(function (_prxperiment_) {
-    prxperiment = _prxperiment_;
-    prxperiment.flushActive();
-  }));
-
-  it ('can do experiments', function () {
-    expectParticipationRequest('option2');
-    var p;
-    prxperiment.run('experiment', ['option1', 'option2']).then(function (participation) {
-      p = participation;
+      inject(function (prxperiment) {
+        expect(prxperiment.clientId).toResolveTo('testing');
+      });
     });
-    flush();
-    expect(p.alternative).toEqual('option2');
+
+    it ('can be disabled', function () {
+      module('prx.experiments', function (prxperimentProvider) {
+        prxperimentProvider.enabled(false);
+      });
+
+      inject(function (prxperiment) {
+        expect(prxperiment.run('experiment', ['asd', 'fgh']).then(function (x) { return x.toString(); })).toResolveTo('asd');
+      });
+    });
   });
 
-  it ('can force existing experiments to have a certain value', function () {
-    expectParticipationRequest('option2');
-    var x, p = prxperiment.run('experiment', ['option1', 'option2']).then(function (c) { x = c; });
-    flush();
-    expect(x.choice).toEqual('option2');
-    prxperiment.addForce('experiment', 'option1');
-    expect(x.choice).toEqual('option1');
+
+  describe ('when configured', function () {
+    var prxperiment;
+
+    beforeEach(module('prx.experiments', function (prxperimentProvider) {
+      prxperimentProvider.clientId('fooBar').base('');
+    }));
+
+    beforeEach(inject(function (_prxperiment_) {
+      prxperiment = _prxperiment_;
+      prxperiment.flushActive();
+    }));
+
+    it ('can do experiments', function () {
+      expectParticipationRequest('option2');
+      var p;
+      prxperiment.run('experiment', ['option1', 'option2']).then(function (participation) {
+        p = participation;
+      });
+      flush();
+      expect(p.alternative).toEqual('option2');
+    });
+
+    it ('memoizes experiments', function () {
+      var exp = prxperiment.run('experiment', ['option2', 'option3']);
+      expect(prxperiment.run('experiment')).toBe(exp);
+    });
+
+    it ('can force existing experiments to have a certain value', function () {
+      expectParticipationRequest('option2');
+      var x, p = prxperiment.run('experiment', ['option1', 'option2']).then(function (c) { x = c; });
+      flush();
+      expect(x.choice).toEqual('option2');
+      prxperiment.addForce('experiment', 'option1');
+      expect(x.choice).toEqual('option1');
+    });
+
+    it ('can force experiments before they are run', function () {
+      prxperiment.addForce('experiment', 'okval');
+      expectParticipationRequest('nokayval');
+      var x, p = prxperiment.run('experiment', ['nokayval', 'okval']).then(function (c) { x = c; });
+      flush();
+      expect(x.choice).toEqual('okval');
+    });
+
+    it ('can force experiments before they are resolved', function () {
+      expectParticipationRequest('4');
+      var x, p = prxperiment.run('xp', ['1', '2', '3', '4']).then(function (c) { x = c; });
+      prxperiment.addForce('xp', '2');
+      flush();
+      expect(x.choice).toEqual('2');
+    });
+
+    it ('refuses to force an invalid alternative', function () {
+      expectParticipationRequest('1');
+      var x, p = prxperiment.run('xp', ['1', '2']).then(function (c) { x = c; });
+      prxperiment.addForce('xp', '3');
+      flush();
+      expect(x.choice).toEqual('1');
+    });
+
+    it ('can convert', function () {
+      expectParticipationRequest('1');
+      expectConversion('xp');
+      prxperiment.run('xp', ['1', '2']).convert();
+      flush();
+    });
+
+    it ('can convert with kpi', function () {
+      expectParticipationRequest('1');
+      expectConversion('xp', 'asd');
+      prxperiment.run('xp', ['1', '2']).convert('asd');
+      flush();
+    });
+
+    it ('calls toString the choice', function () {
+      expectParticipationRequest('option2');
+      var x;
+      prxperiment.run('experiment', ['option1', 'option2']).then(function (p) { x = p; });
+      flush();
+      expect(x.toString()).toEqual('option2');
+    });
+
+    it ('flushes active experiments on the start of state changes', inject(function ($rootScope) {
+      spyOn(prxperiment, 'flushActive');
+      $rootScope.$broadcast('$stateChangeStart');
+      expect(prxperiment.flushActive).toHaveBeenCalled();
+    }));
+
+    it ('flushes active experiments by calling unforce on them', function () {
+      expectParticipationRequest('option1');
+      var exp = prxperiment.run('experiment', ['option1', 'option2']);
+      spyOn(exp, 'unforce');
+      prxperiment.flushActive();
+      expect(exp.unforce).toHaveBeenCalled();
+    });
+
+    it ('unforces post resolve', function () {
+      expectParticipationRequest('option1');
+      var exp = prxperiment.run('experiment', ['option1', 'option2']);
+      exp.set('option2');
+      flush();
+      expect(exp.then(function (s) { return s.toString(); })).toResolveTo('option2');
+      exp.unforce();
+      expect(exp.then(function (s) { return s.toString(); })).toResolveTo('option1');
+    });
+
+    it ('unforces pre resolve', function () {
+      expectParticipationRequest('option1');
+      var exp = prxperiment.run('experiment', ['option1', 'option2']);
+      exp.set('option2');
+      exp.unforce();
+      flush();
+      expect(exp.then(function (s) { return s.toString(); })).toResolveTo('option1');
+    });
+
+    it ('noops when unforce is meaningless', function () {
+      expectParticipationRequest('option1');
+      var exp = prxperiment.run('experiment', ['option1', 'option2']);
+      flush();
+      exp.unforce();
+      expect(exp.then(function (s) { return s.toString(); })).toResolveTo('option1');
+    });
+
+    describe ('get', function () {
+      it ('returns the resolved participation', function () {
+        expectParticipationRequest('option1');
+        var exp = prxperiment.run('experiment', ['option1', 'option2']);
+        expect(prxperiment.get('experiment')).not.toBeDefined();
+        flush();
+        expect(prxperiment.get('experiment')).toBeDefined();
+        expect(exp).toResolveTo(prxperiment.get('experiment'));
+      });
+    });
+
+    describe ('tryconvert', function () {
+      it ('converts an experiment if it is running', function () {
+        expectParticipationRequest('option1');
+        prxperiment.run('experiment', ['option1', 'option2']).then(function (x) {
+          spyOn(x, 'convert');
+          return x;
+        });
+        prxperiment.tryConvert('experiment');
+        flush();
+        expect(prxperiment.get('experiment').convert).toHaveBeenCalled();
+      });
+
+      it ('does nothing if the experiment is not running', function () {
+        prxperiment.tryConvert('experiment');
+      });
+    });
+
+    it ('adds forces automatically when the query is updated', inject(function ($location, $rootScope) {
+      spyOn(prxperiment, 'addForce');
+      $location.search('ok', 'yes');
+      $rootScope.$apply();
+      $location.search('prxp-force-name', 'value');
+      $rootScope.$apply();
+      expect(prxperiment.addForce).toHaveBeenCalledWith('name', 'value');
+    }));
   });
-
-  it ('can force experiments before they are run', function () {
-    prxperiment.addForce('experiment', 'okval');
-    expectParticipationRequest('nokayval');
-    var x, p = prxperiment.run('experiment', ['nokayval', 'okval']).then(function (c) { x = c; });
-    flush();
-    expect(x.choice).toEqual('okval');
-  });
-
-  it ('can force experiments before they are resolved', function () {
-    expectParticipationRequest('4');
-    var x, p = prxperiment.run('xp', ['1', '2', '3', '4']).then(function (c) { x = c; });
-    prxperiment.addForce('xp', '2');
-    flush();
-    expect(x.choice).toEqual('2');
-  });
-
-  it ('refuses to force an invalid alternative', function () {
-    expectParticipationRequest('1');
-    var x, p = prxperiment.run('xp', ['1', '2']).then(function (c) { x = c; });
-    prxperiment.addForce('xp', '3');
-    flush();
-    expect(x.choice).toEqual('1');
-  });
-
-  it ('can convert', function () {
-    expectParticipationRequest('1');
-    expectConversion('xp');
-    prxperiment.run('xp', ['1', '2']).convert();
-    flush();
-  });
-
-  it ('can convert with kpi', function () {
-    expectParticipationRequest('1');
-    expectConversion('xp', 'asd');
-    prxperiment.run('xp', ['1', '2']).convert('asd');
-    flush();
-  });
-
-  it ('calls toString the choice', function () {
-    expectParticipationRequest('option2');
-    var x;
-    prxperiment.run('experiment', ['option1', 'option2']).then(function (p) { x = p; });
-    flush();
-    expect(x.toString()).toEqual('option2');
-  });
-
-  it ('flushes active experiments on the start of state changes', inject(function ($rootScope) {
-    spyOn(prxperiment, 'flushActive');
-    $rootScope.$broadcast('$stateChangeStart');
-    expect(prxperiment.flushActive).toHaveBeenCalled();
-  }));
-
-  it ('adds forces automatically when the query is updated', inject(function ($location, $rootScope) {
-    spyOn(prxperiment, 'addForce');
-    $location.search('ok', 'yes');
-    $rootScope.$apply();
-    $location.search('prxp-force-name', 'value');
-    $rootScope.$apply();
-    expect(prxperiment.addForce).toHaveBeenCalledWith('name', 'value');
-  }));
 });

--- a/src/common/spec-helpers.spec.js
+++ b/src/common/spec-helpers.spec.js
@@ -1,0 +1,44 @@
+beforeEach(function () {
+  jasmine.addMatchers({
+    toResolveTo: function (util, customEquality) {
+      return {
+        compare: function (actual, expected) {
+          var complete = false;
+          inject(function ($q, $rootScope) {
+            $rootScope.$apply(function () {
+              $q.when(actual).then(function (result) {
+                complete = true;
+                actual = result;
+              });
+            });
+          });
+          if (!complete) {
+            return { pass: false, message: "Expected promise to resolve."};
+          }
+          var result = {pass: util.equals(actual, expected, customEquality)};
+          if (result.pass) {
+            result.message = "Expected promise not to resolve to " + actual;
+          } else {
+            result.message = "Expected promised " + actual + " to resolve to " + expected;
+          }
+          return result;
+        }
+      };
+    },
+    toResolve: function () {
+      return {
+        compare: function (actual) {
+          var result = {pass: false};
+          inject(function ($q, $rootScope) {
+            $rootScope.$apply(function () {
+              $q.when(actual).then(function () {
+                result.pass = true;
+              });
+            });
+          });
+          return result;
+        }
+      };
+    }
+  });
+});


### PR DESCRIPTION
The `FEAT.APPLICATION_VERSION` flag will be set to `"development"` when running locally and `"integration"` for our e2e tests (or when running locally against the `compiled` build target), and to the sha of the version in use when deployed.

I take advantage of this to know when to avoid hitting the A/B testing backend and polluting it with meaningless data. Prior to this change, it was using the google analytics user id when available and the singleton user "tests" when google analytics was not on the page (i.e. in the non-compiled version of the page). This meant that at most one participant and conversion would be added during development, but integration tests could cause the app to trigger more.

I've moved my promise-based matchers out of the ng-hal-mock module to a top-level place within the app since they're almost always useful. This allows you to `ddescribe` or `iit` without worrying about whether `angular-hal-mock` is being required by that test before you use `.toResolveTo()`.

When disabled, the prxperiment system will always choose the first ("control") alternative unless it has been overridden. In development, use the overriding (`?prxp-force-[experimentName]=[alternativeName]`) to see the different alternatives.
