### PR TITLE
make sure that the back button shows history correctly

### DIFF
--- a/src/app/breadcrumbs-service.js
+++ b/src/app/breadcrumbs-service.js
@@ -1,5 +1,5 @@
 angular.module('prx.breadcrumbs', ['ui.router'])
-.factory('stateCrumbs', function ($rootScope, $state, $injector) {
+.factory('stateCrumbs', function ($rootScope, $state, $injector, $window, $timeout) {
   var stateCrumbs = {
     crumbs: [],
     title: "",
@@ -8,26 +8,32 @@ angular.module('prx.breadcrumbs', ['ui.router'])
   };
 
   function setTitle () {
-    var crumbs = [], depth = 0, title, cState = $state.$current;
+    $timeout(function () {
+      var crumbs = [], depth = 0, title, cState = $state.$current;
 
-    while (cState) {
-      if (cState.self.title) {
-        title = cState.self.title;
-        if (angular.isFunction(title) ||
-          (angular.isArray(title) && angular.isFunction(title[title.length-1]))) {
-            title = $injector.invoke(title, cState.self, cState.locals.globals);
+      while (cState) {
+        if (cState.self.title) {
+          title = cState.self.title;
+          if (angular.isFunction(title) ||
+            (angular.isArray(title) && angular.isFunction(title[title.length-1]))) {
+              title = $injector.invoke(title, cState.self, cState.locals.globals);
+          }
+          crumbs.push(mkCrumb(title, cState.self, depth));
         }
-        crumbs.push(mkCrumb(title, cState.self, depth));
+        depth += 1;
+        cState = cState.parent;
       }
-      depth += 1;
-      cState = cState.parent;
-    }
 
-    if (crumbs.length) {
-      stateCrumbs.title = crumbs[0].title + (stateCrumbs.suffix || '');
-    }
+      if (crumbs.length) {
+        stateCrumbs.title = crumbs[0].title + (stateCrumbs.suffix || '');
+      }
 
-    stateCrumbs.crumbs = crumbs;
+      stateCrumbs.crumbs = crumbs;
+
+      if ($window.history.replaceState) {
+        $window.history.replaceState({}, stateCrumbs.title);
+      }
+    });
   }
 
   $rootScope.$on('$stateChangeSuccess', setTitle);
@@ -62,6 +68,7 @@ angular.module('prx.breadcrumbs', ['ui.router'])
       tElem.attr('ng-bind', "stateCrumbs.title");
       return function (scope, iElem) {
         scope.stateCrumbs = stateCrumbs;
+        stateCrumbs.title = tElem.text();
         $compile(iElem)(scope);
       };
     }

--- a/src/app/breadcrumbs-service.spec.js
+++ b/src/app/breadcrumbs-service.spec.js
@@ -1,5 +1,5 @@
 describe('breadcrumb service', function () {
-  var stateCrumbs, $state, $rootScope;
+  var stateCrumbs, $state, $rootScope, $timeout;
 
   beforeEach(module('prx.breadcrumbs', function ($stateProvider) {
     $stateProvider.state('base', {
@@ -31,11 +31,12 @@ describe('breadcrumb service', function () {
     });
   }));
 
-  beforeEach(inject(function (_stateCrumbs_, _$state_, _$rootScope_) {
-    stateCrumbs = _stateCrumbs_; $state = _$state_; $rootScope = _$rootScope_;
+  beforeEach(inject(function (_stateCrumbs_, _$state_, _$rootScope_, _$timeout_) {
+    stateCrumbs = _stateCrumbs_; $state = _$state_; $rootScope = _$rootScope_; $timeout = _$timeout_;
     $rootScope.$apply(function () {
       $state.go('base.noTitle.nested.againNoTitle.last');
     });
+    $timeout.flush();
   }));
 
   it ('works', function () {
@@ -54,7 +55,7 @@ describe('breadcrumb service', function () {
   it ('can reset suffix', function () {
     stateCrumbs.setSuffix('asdf');
     $state.go('base.noTitle.nested.againNoTitle');
-    $rootScope.$digest();
+    $timeout.flush();
     expect(stateCrumbs.title).toEqual("fooFromResolveasdf");
     stateCrumbs.setSuffix('foo');
     expect(stateCrumbs.title).toEqual("fooFromResolvefoo");
@@ -72,13 +73,6 @@ describe('breadcrumb service', function () {
       $compile("<title>asd</title>")($scope);
       expect(stateCrumbs.setSuffix).toHaveBeenCalled();
       expect(stateCrumbs.setSuffix.calls.mostRecent().args[0]).toEqual(' on asd');
-    });
-
-    it ('sets the value', function () {
-      var elm = $compile("<title>foo</title>")($scope);
-      $state.go('base.noTitle.nested.againNoTitle.last');
-      $rootScope.$digest();
-      expect(elm.text()).toEqual("overrideResolve on foo");
     });
   });
 


### PR DESCRIPTION
We're just deferring setting the title until after the pushState() call has been made within the bowels of ui-router so that the history looks right (previously, pressing and holding the back button would show titles that were off by one)

I'm also using the title parameter of replaceState (which is otherwise a noop) because I suspect that's what google is using for their crawler to determine the title of a page:

https://www.google.com/search?q=site%3A+m.prx.org&oq=site%3A+m.prx.org&aqs=chrome..69i57j69i58.4311j0j7&sourceid=chrome&es_sm=91&ie=UTF-8#q=site:m.prx.org
