### PR TITLE
Fix very long listens

### DIFF
--- a/src/app/player/player.js
+++ b/src/app/player/player.js
@@ -98,7 +98,7 @@ angular.module('prx.player', ['ngPlayerHater', 'angulartics', 'prx.bus'])
         var position = Math.round(this.nowPlaying.position / 1000);
         if (force || (position - this.$lastHeartbeat) >= 15) {
           var seconds = position - this.$lastHeartbeat;
-          if (seconds > 60) { seconds = 15; }
+          if (seconds > 60 || seconds < 0.5) { seconds = 15; }
           Bus.emit('audioPlayer.listen', this.nowPlaying, seconds, this.$lastHeartbeat);
           this.$lastHeartbeat = position;
         }


### PR DESCRIPTION
#### Normalize listen durations, defang erroneously long listens. …

Sometimes, listens are coming in with extremely long durations.

Basically, in the event that the browser has gone really wonky, we
treat it as a 15 second listen.

---
#### Normalize negative listen durations, as well.

There's a (small) chance that some of the extremely high values are so
high because Google Analytics converts from a signed integer to an
unsigned integer, making a negative number into an extremely large positive
number.

This seeks to address that. I added a small window (of under 0.5 seconds)
because it felt right to do so. Not sure if it actually makes sense.
