### PR TITLE
Cache assets between deploys

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,8 +2,13 @@ lock '~> 3.1'
 
 set :application, 'prx.org-frontend'
 set :repo_url, 'git://github.com/PRX/PRX.org-frontend.git'
-set :linked_dirs, %w{node_modules tmp}
+set :linked_dirs, %w{node_modules tmp .cache}
 set :default_env, { path: "/opt/node/current/bin:/opt/python/current/bin:$PATH" }
+set :revision_timestamp, (proc do
+   rev = fetch(:current_revision)
+   out = `git rev-list --format=format:'%ct' --max-count=1 #{rev}|tail -1`
+   Time.at(out.chomp.to_i).strftime('%Y%m%d%H%M.%S')
+ end)
 
 namespace :deploy do
   desc 'Compile assets'
@@ -16,6 +21,7 @@ namespace :deploy do
           execute :rm, '-rf public'
           execute :ln, '-s bin/ public'
           execute :ln, '-s lib/server.js app.js'
+          execute :find, ".cache/ -exec touch -t '#{fetch(:revision_timestamp)}' {} \\; ; true"
         end
       end
     end


### PR DESCRIPTION
This speeds up deploys considerably by caching the minified assets.

There is a concern, though, that changes may not be picked up because it just
uses timestamps. As a result, we manually set the timestamps of files generated
by the build process into the cache to be the timestamp of the commit being
deployed.

This could cause problems if file timestamps are dramatically behind the commit
timestamps (the specific case involves a deploy happening between a file
being created and that file being committed for the first time) but this can
be addressed in the future by first touching the source assets with the commit's
timestamp which, while I am not yet doing, should protect us completely.

I'd also like to consider using a copy instead of the symlink used here because
there are definitely race conditions at play if multiple deploys are happening
simultaneously.
