### PR TITLE
SVG play/pause

### DIFF
--- a/src/app/player/player.styl
+++ b/src/app/player/player.styl
@@ -52,9 +52,11 @@ $player-button {
   height: 70px;
   background-position: center center;
   background-repeat: no-repeat;
-  image: '/assets/images/bt_pause.png' auto 25px;
+  background-image: url('/assets/images/bt_pause.svg');
+  background-size: 23px 25px;
   &.play {
-    image: '/assets/images/bt_play.png' auto 25px;
+    background-image: url('/assets/images/bt_play.svg');
+    background-size: 16px 24px;
   }
   &.loading:not(.play) {
     background-image: none;

--- a/src/app/series/series.styl
+++ b/src/app/series/series.styl
@@ -160,7 +160,7 @@ article.series {
             left: 0;
             bottom: 0;
             width: 40px;
-            background: orange url('/assets/images/bt_play.png') center center / 12px no-repeat;
+            // background: orange url('/assets/images/bt_play.png') center center / 12px no-repeat;
           }
         }
       }

--- a/src/app/stories/stories.styl
+++ b/src/app/stories/stories.styl
@@ -287,12 +287,13 @@ section.story {
         absolute: bottom left;
         width: 25px;
         height: 25px;
-        background: rgba(orange, 0.9) url('/assets/images/bt_play.png') center center / 12px no-repeat;
+        background: rgba(orange, 0.9) url('/assets/images/bt_play.svg') center center / 8px no-repeat;
         content: '';
       }
 
       &.playing:before {
-        background-image: url('/assets/images/bt_pause.png');
+        background-image: url('/assets/images/bt_pause.svg');
+        background-size: 12px;
       }
     }
   }

--- a/src/assets/images/bt_pause.svg
+++ b/src/assets/images/bt_pause.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="23" height="25" version="1.1" xml:space="preserve"><path d="M0 0L0 25 8 25 8 0 0 0M15 0L15 25 23 25 23 0 15 0Z" fill="white"/></svg>

--- a/src/assets/images/bt_play.svg
+++ b/src/assets/images/bt_play.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="24" version="1.1" xml:space="preserve"><path d="M0 0L0 24 16 12 0 0Z" fill="white"/></svg>


### PR DESCRIPTION
I ran some numbers, and I think SVGs vs optimized PNGs for these basic shape images are basically the same size. Reducing use of the `image` mixin also reduces a decent amount of media queries, so size on the wire I think this is net smaller. Plus this eliminates the need for multiple sizes, and since we reuse some of these images at non-native sizes this should also render better.

Just wanted to start the conversation.
