### PR TITLE
Disable curation expander

### DIFF
--- a/src/app/picks/picks.styl
+++ b/src/app/picks/picks.styl
@@ -66,6 +66,7 @@ section.picks.gallery {
       p.expander {
         visibility: hidden;
         position: absolute;
+        display: none;
       }
     }
   }


### PR DESCRIPTION
The “show more” functionality has been disabled already, so this
doesn’t really affect anything. Both aspects of the homepage should be
fixed at some point.