### PR TITLE
Use "private" as UID when GA is blocked.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -71,10 +71,13 @@
   z.src = "http://"+window.location.hostname+":35729/livereload.js";
   document.body.appendChild(z);</script>
 <% } else { %><script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (function(i,s,o,g,r,e,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;a[e]=function(){i[r][e]()};m.
+  parentNode.insertBefore(a,m)})(window,document,'script',
+  '//www.google-analytics.com/analytics.js','ga','onerror');
+  ga.onerror=function(){function o(c){if(typeof c=='function')c({get:g})}for(var
+  n=ga.q,i=0;i<n.length;i++)o.apply(n,n[i]);function g(){return'private'}ga=o};
   ga('create', 'UA-164824-46', 'prx.org');
   ga('set', 'dimension1', FEAT.APPLICATION_VERSION);
   ga('require', 'displayfeatures');


### PR DESCRIPTION
µBlock blocks www.google-analytics.com by default, which prevents the tracker
callbacks from ever executing and giving us the GA UID, which we use for
x.prx.org.

This patch detects such blocking and then always returns "private" as the UID,
which prevents pages from stalling awaiting the UID callback and should be
sufficient for the privacy conscious.

Also, it's written in the style of the google analytics loader, which is to say *insane*.