### PR TITLE
Switch href to url in build links

### DIFF
--- a/src/common/angular-hal.js
+++ b/src/common/angular-hal.js
@@ -78,7 +78,7 @@ angular.module('angular-hal', ['ng', 'uri-template'])
       return this.context.makeConstructor([link.profile(params), rel])({
         _links: {
           create: {
-            href:link.href(params)
+            href:link.url(params)
           }
         }
       }, undefined);


### PR DESCRIPTION
This doesn't look like it's getting tested explicitly right now. May be worth adding.